### PR TITLE
feat(Vox/Renderer): add Vulkan backend infrastructure

### DIFF
--- a/AGENT.md
+++ b/AGENT.md
@@ -1,0 +1,27 @@
+# AGENT.md
+
+Graphics programming project with C++20, CMake, OpenGL/Vulkan. Two main apps: `cube23` (OpenGL 3.3+ + Vox engine) and `cube23_vk` (standalone Vulkan).
+
+## Build Commands
+```bash
+# Configure and build (from project root)
+cmake -B cmake-build-debug -G Ninja -DCMAKE_BUILD_TYPE=Debug
+cmake --build cmake-build-debug --target cube23 -j 10      # OpenGL app
+cmake --build cmake-build-debug --target cube23_vk -j 10    # Vulkan app
+
+# Test/verify build
+./test.sh                                                    # Docker-based CI test
+```
+
+## Architecture
+- **Vox engine** (`vox/src/`): OpenGL 3.3 Core renderer abstraction (Application, Buffer, Shader, Texture, VertexArray)
+- **cube23** (`cube23/src/cube_app.cpp`): OpenGL app using Vox engine
+- **cube23_vk** (`cube23/src/main.cpp`): Standalone Vulkan implementation
+- **Assets**: `cube23/assets/` → auto-copied to build dir, GLSL shaders compiled to SPIR-V
+
+## Code Style
+- C++20, `#pragma once`, namespace `Vox` for engine
+- Naming: `camelCase` methods, `mMember` variables, `ClassName` types
+- Headers: system includes first, then local includes with relative paths
+- Smart pointers: `std::shared_ptr`, `std::unique_ptr` with `.reset()` pattern
+- GLM for math, GLFW for windowing, platform abstraction in `platform/opengl/`

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -61,6 +61,17 @@ set(Vox_SOURCES
         vox/src/platform/opengl/texture.h
         vox/src/platform/opengl/vertex_array.cpp
         vox/src/platform/opengl/vertex_array.h
+
+        vox/src/platform/vulkan/vulkan_buffer.cpp
+        vox/src/platform/vulkan/vulkan_buffer.h
+        vox/src/platform/vulkan/vulkan_renderer_api.cpp
+        vox/src/platform/vulkan/vulkan_renderer_api.h
+        vox/src/platform/vulkan/vulkan_shader.cpp
+        vox/src/platform/vulkan/vulkan_shader.h
+        vox/src/platform/vulkan/vulkan_texture.cpp
+        vox/src/platform/vulkan/vulkan_texture.h
+        vox/src/platform/vulkan/vulkan_vertex_array.cpp
+        vox/src/platform/vulkan/vulkan_vertex_array.h
 )
 
 add_library(vox STATIC ${Vox_SOURCES})

--- a/notes/opengl-version-analysis.md
+++ b/notes/opengl-version-analysis.md
@@ -1,0 +1,163 @@
+# OpenGL Version Analysis for Cube23/Vox Engine
+
+## Overview
+This document analyzes the OpenGL usage in the Vox engine and cube23 project to determine the minimum OpenGL version requirements and evaluate compatibility options.
+
+## Current OpenGL Usage
+
+### Context Configuration
+- **Target Version**: OpenGL 3.3 Core Profile
+- **Location**: `vox/src/vox/window.cpp:32-34`
+- **Forward Compatibility**: Enabled on macOS
+
+### Core OpenGL Functions Used
+
+#### Buffer Management (OpenGL 1.5+)
+- `glGenBuffers`, `glBindBuffer`, `glBufferData`, `glDeleteBuffers`
+- Used in: `vox/src/platform/opengl/buffer.cpp`
+- Purpose: Vertex and index buffer management
+
+#### Vertex Array Objects (OpenGL 3.0+)
+- `glGenVertexArrays`, `glBindVertexArray`, `glDeleteVertexArrays`
+- `glVertexAttribPointer`, `glEnableVertexAttribArray`
+- Used in: `vox/src/platform/opengl/vertex_array.cpp`
+- **Critical**: Required for Core Profile rendering
+
+#### Shader System (OpenGL 2.0+)
+- `glCreateShader`, `glShaderSource`, `glCompileShader`
+- `glCreateProgram`, `glAttachShader`, `glLinkProgram`, `glUseProgram`
+- Used in: `vox/src/platform/opengl/shader.cpp`
+- **Current GLSL Version**: `#version 330 core`
+
+#### Uniform Management (OpenGL 2.0+)
+- `glGetUniformLocation`, `glUniform1i/1f/2f/3f/4f`
+- `glUniformMatrix3fv`, `glUniformMatrix4fv`
+- Used in: `vox/src/platform/opengl/shader.cpp`
+
+#### Texture Management (OpenGL 1.3+)
+- `glGenTextures`, `glBindTexture`, `glTexImage2D`, `glTexParameteri`
+- `glActiveTexture` (multiple texture unit support)
+- Used in: `vox/src/platform/opengl/texture.cpp`
+- **Formats**: RGB8, RGBA8 internal formats
+
+#### Rendering Commands (OpenGL 1.1+)
+- `glDrawElements`, `glClear`, `glClearColor`
+- `glBlendFunc`, `glEnable/glDisable`
+- Used in: `vox/src/platform/opengl/renderer_api.cpp`
+
+## Minimum Version Requirements Analysis
+
+### Feature Dependencies
+1. **Vertex Array Objects**: OpenGL 3.0+ (mandatory for Core Profile)
+2. **GLSL 330**: OpenGL 3.3+
+3. **Core Profile**: OpenGL 3.2+
+4. **Modern Shader Pipeline**: OpenGL 2.0+
+
+### Current Minimum: OpenGL 3.3 Core Profile
+This is the actual minimum required due to:
+- VAO dependency for Core Profile rendering
+- GLSL 330 shader version
+- Core Profile context requirement
+
+## Compatibility Assessment
+
+### Hardware Support
+- **OpenGL 3.3**: Supported by all GPUs from 2010+
+- **Coverage**: Intel HD Graphics 2000+, AMD Radeon HD 5000+, NVIDIA GeForce 8000+
+- **Compatibility**: Excellent for modern systems
+
+### Alternative Version Targets
+
+#### Option 1: Lower to OpenGL 3.0/3.1
+**Pros:**
+- Broader hardware support (2008+ GPUs)
+- Still supports VAOs and modern shaders
+
+**Cons:**
+- Would need GLSL version downgrade to `#version 130` or `#version 140`
+- Minor syntax changes required in shaders
+- Loss of some Core Profile benefits
+
+**Changes Required:**
+```glsl
+// Current (GLSL 330)
+#version 330 core
+layout(location = 0) in vec3 a_position;
+layout(location = 0) out vec4 color;
+
+// Alternative (GLSL 130)
+#version 130
+attribute vec3 a_position;  // instead of 'in'
+varying vec2 v_texCoord;    // instead of 'out'
+```
+
+#### Option 2: Keep OpenGL 3.3 Core (Recommended)
+**Pros:**
+- Clean, modern API without legacy baggage
+- Excellent hardware support for target use case
+- No deprecated functions to avoid
+- Current implementation is optimal
+
+**Cons:**
+- Excludes very old hardware (10+ years)
+- May not work on some embedded systems
+
+#### Option 3: Runtime Capability Detection
+**Implementation:**
+- Query OpenGL version at startup
+- Provide multiple shader versions
+- Fallback rendering paths
+
+**Complexity:**
+- Significantly more code maintenance
+- Multiple shader versions to maintain
+- Testing burden across versions
+
+## Shader Analysis
+
+### Current Shaders
+- **Location**: `cube23/assets/shaders/texture.glsl`
+- **Version**: `#version 330 core`
+- **Features Used**:
+  - Layout qualifiers (`layout(location = 0)`)
+  - Modern in/out qualifiers
+  - Built-in variables (`gl_Position`)
+  - Texture sampling (`texture()` function)
+
+### Shader Compatibility Notes
+- GLSL 330 `texture()` function vs older `texture2D()`
+- Layout qualifiers are more explicit than older attribute binding
+- Modern syntax is cleaner and less error-prone
+
+## Recommendations
+
+### Primary Recommendation: Maintain OpenGL 3.3 Core
+**Rationale:**
+1. **Appropriate Target**: Covers all hardware from 2010+
+2. **Clean Implementation**: No legacy code paths needed
+3. **Future-Proof**: Good foundation for potential modern features
+4. **Development Efficiency**: Single code path to maintain
+
+### Secondary Options
+1. **If broader compatibility needed**: Target OpenGL 3.0 with GLSL 130
+2. **If cutting-edge features desired**: Consider OpenGL 4.0+ for advanced rendering
+
+### Implementation Notes
+- Current implementation is well-structured for OpenGL 3.3
+- VAO usage is mandatory and properly implemented
+- Shader system handles modern GLSL correctly
+- Buffer management follows best practices
+
+## Conclusion
+
+The current OpenGL 3.3 Core Profile requirement is appropriate and well-implemented. It provides:
+- Excellent compatibility (2010+ hardware)
+- Clean, modern API usage
+- Maintainable codebase
+- Good performance characteristics
+
+**No changes recommended** unless specific compatibility requirements arise for older hardware.
+
+---
+*Analysis performed: January 2025*
+*Files analyzed: vox/src/platform/opengl/*, cube23/assets/shaders/*

--- a/vox/src/platform/vulkan/vulkan_buffer.cpp
+++ b/vox/src/platform/vulkan/vulkan_buffer.cpp
@@ -1,0 +1,38 @@
+#include "vulkan_buffer.h"
+
+namespace Vox {
+    // VulkanVertexBuffer
+    VulkanVertexBuffer::VulkanVertexBuffer(float *vertices, uint32_t size) {
+        // TODO: Create Vulkan vertex buffer
+    }
+
+    VulkanVertexBuffer::~VulkanVertexBuffer() {
+        // TODO: Cleanup Vulkan buffer
+    }
+
+    void VulkanVertexBuffer::bind() const {
+        // TODO: Bind Vulkan vertex buffer
+    }
+
+    void VulkanVertexBuffer::unbind() const {
+        // TODO: Unbind Vulkan vertex buffer
+    }
+
+    // VulkanIndexBuffer
+    VulkanIndexBuffer::VulkanIndexBuffer(uint32_t *indices, uint32_t count)
+        : mCount(count) {
+        // TODO: Create Vulkan index buffer
+    }
+
+    VulkanIndexBuffer::~VulkanIndexBuffer() {
+        // TODO: Cleanup Vulkan buffer
+    }
+
+    void VulkanIndexBuffer::bind() const {
+        // TODO: Bind Vulkan index buffer
+    }
+
+    void VulkanIndexBuffer::unbind() const {
+        // TODO: Unbind Vulkan index buffer
+    }
+}

--- a/vox/src/platform/vulkan/vulkan_buffer.h
+++ b/vox/src/platform/vulkan/vulkan_buffer.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include "vox/renderer/buffer.h"
+
+namespace Vox {
+    class VulkanVertexBuffer : public VertexBuffer {
+    public:
+        VulkanVertexBuffer(float *vertices, uint32_t size);
+        virtual ~VulkanVertexBuffer();
+
+        void bind() const override;
+        void unbind() const override;
+
+        const BufferLayout &getLayout() const override { return mLayout; }
+        void setLayout(const BufferLayout &layout) override { mLayout = layout; }
+
+    private:
+        BufferLayout mLayout;
+        // TODO: Add Vulkan buffer handles
+    };
+
+    class VulkanIndexBuffer : public IndexBuffer {
+    public:
+        VulkanIndexBuffer(uint32_t *indices, uint32_t count);
+        virtual ~VulkanIndexBuffer();
+
+        void bind() const override;
+        void unbind() const override;
+
+        uint32_t getCount() const override { return mCount; }
+
+    private:
+        uint32_t mCount;
+        // TODO: Add Vulkan buffer handles
+    };
+}

--- a/vox/src/platform/vulkan/vulkan_renderer_api.cpp
+++ b/vox/src/platform/vulkan/vulkan_renderer_api.cpp
@@ -1,0 +1,19 @@
+#include "vulkan_renderer_api.h"
+
+namespace Vox {
+    void VulkanRendererAPI::init() {
+        // TODO: Initialize Vulkan context
+    }
+
+    void VulkanRendererAPI::setClearColor(const glm::vec4 &color) {
+        mClearColor = color;
+    }
+
+    void VulkanRendererAPI::clear() {
+        // TODO: Implement Vulkan clear operation
+    }
+
+    void VulkanRendererAPI::drawIndexed(const std::shared_ptr<VertexArray> &vertexArray) {
+        // TODO: Implement Vulkan indexed drawing
+    }
+}

--- a/vox/src/platform/vulkan/vulkan_renderer_api.h
+++ b/vox/src/platform/vulkan/vulkan_renderer_api.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include "vox/renderer/renderer_api.h"
+
+namespace Vox {
+    class VulkanRendererAPI : public RendererAPI {
+    public:
+        void init() override;
+
+        void setClearColor(const glm::vec4 &color) override;
+        void clear() override;
+
+        void drawIndexed(const std::shared_ptr<VertexArray> &vertexArray) override;
+
+    private:
+        glm::vec4 mClearColor = {0.0f, 0.0f, 0.0f, 1.0f};
+    };
+}

--- a/vox/src/platform/vulkan/vulkan_shader.cpp
+++ b/vox/src/platform/vulkan/vulkan_shader.cpp
@@ -1,0 +1,76 @@
+#include "vulkan_shader.h"
+
+namespace Vox {
+    VulkanShader::VulkanShader(const std::string &filepath) {
+        readFile(filepath);
+        
+        // Extract name from filepath
+        auto lastSlash = filepath.find_last_of("/\\");
+        lastSlash = lastSlash == std::string::npos ? 0 : lastSlash + 1;
+        auto lastDot = filepath.rfind('.');
+        auto count = lastDot == std::string::npos ? filepath.size() - lastSlash : lastDot - lastSlash;
+        mName = filepath.substr(lastSlash, count);
+
+        compileOrGetVulkanBinaries();
+        createShaderModules();
+    }
+
+    VulkanShader::VulkanShader(const std::string &name, const std::string &vertexSrc, const std::string &fragmentSrc)
+        : mName(name) {
+        // TODO: Handle source string compilation for Vulkan
+        compileOrGetVulkanBinaries();
+        createShaderModules();
+    }
+
+    VulkanShader::~VulkanShader() {
+        // TODO: Cleanup Vulkan shader modules
+    }
+
+    void VulkanShader::bind() {
+        // TODO: Bind Vulkan shader (set active pipeline)
+    }
+
+    void VulkanShader::unbind() {
+        // TODO: Unbind Vulkan shader
+    }
+
+    void VulkanShader::setInt(const std::string &name, int value) {
+        // TODO: Set Vulkan uniform via descriptor sets
+    }
+
+    void VulkanShader::setFloat(const std::string &name, float value) {
+        // TODO: Set Vulkan uniform via descriptor sets
+    }
+
+    void VulkanShader::setFloat2(const std::string &name, const glm::vec2 &value) {
+        // TODO: Set Vulkan uniform via descriptor sets
+    }
+
+    void VulkanShader::setFloat3(const std::string &name, const glm::vec3 &value) {
+        // TODO: Set Vulkan uniform via descriptor sets
+    }
+
+    void VulkanShader::setFloat4(const std::string &name, const glm::vec4 &value) {
+        // TODO: Set Vulkan uniform via descriptor sets
+    }
+
+    void VulkanShader::setMat3(const std::string &name, const glm::mat3 &matrix) {
+        // TODO: Set Vulkan uniform via descriptor sets
+    }
+
+    void VulkanShader::setMat4(const std::string &name, const glm::mat4 &matrix) {
+        // TODO: Set Vulkan uniform via descriptor sets
+    }
+
+    void VulkanShader::readFile(const std::string &filepath) {
+        // TODO: Read SPIR-V binary file for Vulkan
+    }
+
+    void VulkanShader::compileOrGetVulkanBinaries() {
+        // TODO: Load pre-compiled SPIR-V binaries
+    }
+
+    void VulkanShader::createShaderModules() {
+        // TODO: Create VkShaderModule objects
+    }
+}

--- a/vox/src/platform/vulkan/vulkan_shader.h
+++ b/vox/src/platform/vulkan/vulkan_shader.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "vox/renderer/shader.h"
+#include <glm/glm.hpp>
+
+namespace Vox {
+    class VulkanShader : public Shader {
+    public:
+        VulkanShader(const std::string &filepath);
+        VulkanShader(const std::string &name, const std::string &vertexSrc, const std::string &fragmentSrc);
+        virtual ~VulkanShader();
+
+        void bind() override;
+        void unbind() override;
+
+        void setInt(const std::string &name, int value);
+        void setFloat(const std::string &name, float value);
+        void setFloat2(const std::string &name, const glm::vec2 &value);
+        void setFloat3(const std::string &name, const glm::vec3 &value);
+        void setFloat4(const std::string &name, const glm::vec4 &value);
+        void setMat3(const std::string &name, const glm::mat3 &matrix);
+        void setMat4(const std::string &name, const glm::mat4 &matrix);
+
+        const std::string &getName() const override { return mName; }
+
+    private:
+        void readFile(const std::string &filepath);
+        void compileOrGetVulkanBinaries();
+        void createShaderModules();
+
+    private:
+        std::string mName;
+        // TODO: Add Vulkan shader handles
+    };
+}

--- a/vox/src/platform/vulkan/vulkan_texture.cpp
+++ b/vox/src/platform/vulkan/vulkan_texture.cpp
@@ -1,0 +1,28 @@
+#include "vulkan_texture.h"
+
+namespace Vox {
+    VulkanTexture2D::VulkanTexture2D(uint32_t width, uint32_t height)
+        : mWidth(width), mHeight(height), mTextureID(0) {
+        // TODO: Create Vulkan image and image view
+    }
+
+    VulkanTexture2D::VulkanTexture2D(const std::string &path)
+        : mPath(path), mTextureID(0) {
+        // TODO: Load image data and create Vulkan image
+        // TODO: Set mWidth and mHeight from loaded image
+        mWidth = 1;
+        mHeight = 1; // Placeholder
+    }
+
+    VulkanTexture2D::~VulkanTexture2D() {
+        // TODO: Cleanup Vulkan image and image view
+    }
+
+    void VulkanTexture2D::setData(void *data, uint32_t size) {
+        // TODO: Update Vulkan image data via staging buffer
+    }
+
+    void VulkanTexture2D::bind(uint32_t slot) const {
+        // TODO: Bind Vulkan texture via descriptor sets
+    }
+}

--- a/vox/src/platform/vulkan/vulkan_texture.h
+++ b/vox/src/platform/vulkan/vulkan_texture.h
@@ -1,0 +1,30 @@
+#pragma once
+
+#include "vox/renderer/texture.h"
+#include <string>
+
+namespace Vox {
+    class VulkanTexture2D : public Texture2D {
+    public:
+        VulkanTexture2D(uint32_t width, uint32_t height);
+        VulkanTexture2D(const std::string &path);
+        virtual ~VulkanTexture2D();
+
+        uint32_t getWidth() const override { return mWidth; }
+        uint32_t getHeight() const override { return mHeight; }
+
+        void setData(void *data, uint32_t size);
+
+        void bind(uint32_t slot = 0) const override;
+
+        bool operator==(const Texture &other) const {
+            return mTextureID == ((VulkanTexture2D&)other).mTextureID;
+        }
+
+    private:
+        std::string mPath;
+        uint32_t mWidth, mHeight;
+        uint32_t mTextureID; // Temporary ID for comparison
+        // TODO: Add Vulkan image handles
+    };
+}

--- a/vox/src/platform/vulkan/vulkan_vertex_array.cpp
+++ b/vox/src/platform/vulkan/vulkan_vertex_array.cpp
@@ -1,0 +1,38 @@
+#include "vulkan_vertex_array.h"
+
+#include <stdexcept>
+
+namespace Vox {
+    VulkanVertexArray::VulkanVertexArray() {
+        // TODO: Initialize Vulkan vertex input state
+    }
+
+    VulkanVertexArray::~VulkanVertexArray() {
+        // TODO: Cleanup Vulkan vertex array resources
+    }
+
+    void VulkanVertexArray::bind() const {
+        // TODO: Set Vulkan pipeline vertex input state
+    }
+
+    void VulkanVertexArray::unbind() const {
+        // TODO: Unset Vulkan vertex input state
+    }
+
+    void VulkanVertexArray::addVertexBuffer(const std::shared_ptr<VertexBuffer> &vertexBuffer) {
+        // Simple assert check without logging macros
+        if (vertexBuffer->getLayout().getElements().empty()) {
+            throw std::runtime_error("Vertex Buffer has no layout!");
+        }
+
+        mVertexBuffers.push_back(vertexBuffer);
+        
+        // TODO: Update Vulkan vertex input attribute descriptions
+    }
+
+    void VulkanVertexArray::setIndexBuffer(const std::shared_ptr<IndexBuffer> &indexBuffer) {
+        mIndexBuffer = indexBuffer;
+        
+        // TODO: Update Vulkan index buffer binding
+    }
+}

--- a/vox/src/platform/vulkan/vulkan_vertex_array.h
+++ b/vox/src/platform/vulkan/vulkan_vertex_array.h
@@ -1,0 +1,25 @@
+#pragma once
+
+#include "vox/renderer/vertex_array.h"
+
+namespace Vox {
+    class VulkanVertexArray : public VertexArray {
+    public:
+        VulkanVertexArray();
+        virtual ~VulkanVertexArray();
+
+        void bind() const override;
+        void unbind() const override;
+
+        void addVertexBuffer(const std::shared_ptr<VertexBuffer> &vertexBuffer) override;
+        void setIndexBuffer(const std::shared_ptr<IndexBuffer> &indexBuffer) override;
+
+        const std::vector<std::shared_ptr<VertexBuffer>> &getVertexBuffers() const override { return mVertexBuffers; }
+        const std::shared_ptr<IndexBuffer> &getIndexBuffer() const override { return mIndexBuffer; }
+
+    private:
+        std::vector<std::shared_ptr<VertexBuffer>> mVertexBuffers;
+        std::shared_ptr<IndexBuffer> mIndexBuffer;
+        // TODO: Add Vulkan pipeline state tracking
+    };
+}

--- a/vox/src/vox/renderer/buffer.cpp
+++ b/vox/src/vox/renderer/buffer.cpp
@@ -5,6 +5,7 @@
 #include "vox/renderer/renderer.h"
 
 #include "platform/opengl/buffer.h"
+#include "platform/vulkan/vulkan_buffer.h"
 
 namespace Vox {
     VertexBuffer *VertexBuffer::create(float *vertices, uint32_t size) {
@@ -13,6 +14,8 @@ namespace Vox {
                 throw std::runtime_error("RendererAPI::None is currently not supported!");
             case RendererAPI::API::OpenGL:
                 return new OpenGLVertexBuffer(vertices, size);
+            case RendererAPI::API::Vulkan:
+                return new VulkanVertexBuffer(vertices, size);
             default:
                 throw std::runtime_error("Unknown RendererAPI!");
         }
@@ -24,6 +27,8 @@ namespace Vox {
                 throw std::runtime_error("RendererAPI::None is currently not supported!");
             case RendererAPI::API::OpenGL:
                 return new OpenGLIndexBuffer(indices, count);
+            case RendererAPI::API::Vulkan:
+                return new VulkanIndexBuffer(indices, count);
             default:
                 throw std::runtime_error("Unknown RendererAPI!");
         }

--- a/vox/src/vox/renderer/render_command.cpp
+++ b/vox/src/vox/renderer/render_command.cpp
@@ -1,7 +1,19 @@
 #include "vox/renderer/render_command.h"
 
 #include "platform/opengl/renderer_api.h"
+#include "platform/vulkan/vulkan_renderer_api.h"
 
 namespace Vox {
-    RendererAPI *RenderCommand::sRendererAPI = new OpenGLRendererAPI();
+    RendererAPI *RenderCommand::sRendererAPI = []() {
+        switch (RendererAPI::getAPI()) {
+            case RendererAPI::API::None:
+                throw std::runtime_error("RendererAPI::None is currently not supported!");
+            case RendererAPI::API::OpenGL:
+                return static_cast<RendererAPI*>(new OpenGLRendererAPI());
+            case RendererAPI::API::Vulkan:
+                return static_cast<RendererAPI*>(new VulkanRendererAPI());
+            default:
+                throw std::runtime_error("Unknown RendererAPI!");
+        }
+    }();
 }

--- a/vox/src/vox/renderer/renderer_api.h
+++ b/vox/src/vox/renderer/renderer_api.h
@@ -10,6 +10,7 @@ namespace Vox {
         enum class API {
             None = 0,
             OpenGL = 1,
+            Vulkan = 2,
         };
 
         virtual void init() = 0;

--- a/vox/src/vox/renderer/shader.cpp
+++ b/vox/src/vox/renderer/shader.cpp
@@ -3,6 +3,7 @@
 #include "vox/renderer/renderer.h"
 
 #include "platform/opengl/shader.h"
+#include "platform/vulkan/vulkan_shader.h"
 
 namespace Vox {
     std::shared_ptr<Shader> Shader::create(const std::string &filepath) {
@@ -11,6 +12,8 @@ namespace Vox {
                 throw std::runtime_error("RendererAPI::None is currently not supported!");
             case RendererAPI::API::OpenGL:
                 return std::make_shared<OpenGLShader>(filepath);
+            case RendererAPI::API::Vulkan:
+                return std::make_shared<VulkanShader>(filepath);
             default:
                 throw std::runtime_error("Unknown RendererAPI!");
         }
@@ -22,6 +25,8 @@ namespace Vox {
                 throw std::runtime_error("RendererAPI::None is currently not supported!");
             case RendererAPI::API::OpenGL:
                 return std::make_shared<OpenGLShader>(name, vertexSrc, fragmentSrc);
+            case RendererAPI::API::Vulkan:
+                return std::make_shared<VulkanShader>(name, vertexSrc, fragmentSrc);
             default:
                 throw std::runtime_error("Unknown RendererAPI!");
         }

--- a/vox/src/vox/renderer/texture.cpp
+++ b/vox/src/vox/renderer/texture.cpp
@@ -3,6 +3,7 @@
 #include "vox/renderer/renderer.h"
 
 #include "platform/opengl/texture.h"
+#include "platform/vulkan/vulkan_texture.h"
 
 namespace Vox {
     std::shared_ptr<Texture2D> Texture2D::create(const std::string &path) {
@@ -11,6 +12,8 @@ namespace Vox {
                 throw std::runtime_error("RendererAPI::None is not supported!");
             case RendererAPI::API::OpenGL:
                 return std::make_shared<OpenGLTexture2D>(path);
+            case RendererAPI::API::Vulkan:
+                return std::make_shared<VulkanTexture2D>(path);
             default:
                 throw std::runtime_error("Unknown RendererAPI!");
         }

--- a/vox/src/vox/renderer/vertex_array.cpp
+++ b/vox/src/vox/renderer/vertex_array.cpp
@@ -3,6 +3,7 @@
 #include "vox/renderer/renderer.h"
 
 #include "platform/opengl/vertex_array.h"
+#include "platform/vulkan/vulkan_vertex_array.h"
 
 namespace Vox {
     VertexArray* VertexArray::create() {
@@ -11,6 +12,8 @@ namespace Vox {
                 throw std::runtime_error("RendererAPI::None is currently not supported!");
             case RendererAPI::API::OpenGL:
                 return new OpenGLVertexArray();
+            case RendererAPI::API::Vulkan:
+                return new VulkanVertexArray();
             default:
                 throw std::runtime_error("Unknown RendererAPI!");
         }


### PR DESCRIPTION
- Add Vulkan enum to RendererAPI::API
- Create platform/vulkan directory structure
- Implement basic Vulkan classes:
  - VulkanRendererAPI
  - VulkanVertexBuffer/VulkanIndexBuffer
  - VulkanShader
  - VulkanTexture2D
  - VulkanVertexArray
- Update all factory methods to support Vulkan backend
- Update CMakeLists.txt to include Vulkan platform files
- All classes have TODO placeholders for actual Vulkan implementation
- Existing OpenGL functionality remains unchanged
- Tests pass successfully

Co-authored-by: Amp <amp@ampcode.com>
Amp-Thread-ID: https://ampcode.com/threads/T-b9bdd109-73bb-47d9-bb9d-99158ef7ed89