### PR TITLE
feat(Vox/Renderer): select backend from environment variable

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -30,7 +30,6 @@ set(Vox_SOURCES
         vox/src/vox/renderer/render_command.h
         vox/src/vox/renderer/renderer.cpp
         vox/src/vox/renderer/renderer.h
-        vox/src/vox/renderer/renderer_api.cpp
         vox/src/vox/renderer/renderer_api.h
         vox/src/vox/renderer/shader.cpp
         vox/src/vox/renderer/shader.h

--- a/test.sh
+++ b/test.sh
@@ -181,17 +181,18 @@ esac
 
 echo "✅ cube23_vk executed successfully"
 
-# Test running cube23 executable (OpenGL)
-echo "🚀 Testing cube23 execution..."
+# Test running cube23 executable (OpenGL backend)
+echo "🚀 Testing cube23 execution (OpenGL backend)..."
 
 case "$EXECUTION_MODE" in
     "linux_x11")
-        echo "🖥️  Running cube23 with X11 forwarding (you should see a window!)"
+        echo "🖥️  Running cube23 with OpenGL and X11 forwarding (you should see a window!)"
 
         docker run --rm --platform linux/amd64 \
             -v "${WORKSPACE_PATH}:/workspace" \
             -e DISPLAY="${DISPLAY}" \
             -e TEST_MODE=1 \
+            -e VOX_RENDERER=opengl \
             -e LIBGL_ALWAYS_SOFTWARE=1 \
             -e XDG_RUNTIME_DIR=/tmp \
             -v /tmp/.X11-unix:/tmp/.X11-unix:rw \
@@ -200,14 +201,14 @@ case "$EXECUTION_MODE" in
             bash -c "cd build && timeout 10s ./cube23"
         ;;
     "mac_x11"|"ci"|"docker_headless"|*)
-        echo "🤖 Running cube23 headless with xvfb"
-        run "cd build && timeout 15s bash -c 'TEST_MODE=1 LIBGL_ALWAYS_SOFTWARE=1 XDG_RUNTIME_DIR=/tmp xvfb-run -a --server-args=\"-screen 0 800x600x24\" bash -c \"./cube23 &
+        echo "🤖 Running cube23 headless with OpenGL backend"
+        run "cd build && timeout 15s bash -c 'TEST_MODE=1 VOX_RENDERER=opengl LIBGL_ALWAYS_SOFTWARE=1 XDG_RUNTIME_DIR=/tmp xvfb-run -a --server-args=\"-screen 0 800x600x24\" bash -c \"./cube23 &
         sleep 4
         import -window root /workspace/screenshot_opengl.png
         wait\"'"
         ;;
 esac
 
-echo "✅ cube23 executed successfully"
+echo "✅ cube23 (OpenGL) executed successfully"
 echo "🎉 Build and execution tests completed successfully!"
 echo "🏁 Test script completed successfully"

--- a/vox/src/vox/renderer/renderer_api.cpp
+++ b/vox/src/vox/renderer/renderer_api.cpp
@@ -1,5 +1,0 @@
-#include "vox/renderer/renderer.h"
-
-namespace Vox {
-    RendererAPI::API RendererAPI::sAPI = API::OpenGL;
-}

--- a/vox/src/vox/renderer/renderer_api.h
+++ b/vox/src/vox/renderer/renderer_api.h
@@ -1,6 +1,8 @@
 #pragma once
 
 #include <glm/glm.hpp>
+#include <cstdlib>
+#include <cstring>
 
 #include "vox/renderer/vertex_array.h"
 
@@ -20,9 +22,15 @@ namespace Vox {
 
         virtual void drawIndexed(const std::shared_ptr<VertexArray> &vertexArray) = 0;
 
-        static API getAPI() { return sAPI; }
-
-    private:
-        static API sAPI;
+        static API getAPI() {
+            static API api = []() {
+                const char* renderer = std::getenv("VOX_RENDERER");
+                if (renderer && strcmp(renderer, "vulkan") == 0) {
+                    return API::Vulkan;
+                }
+                return API::OpenGL; // default
+            }();
+            return api;
+        }
     };
 }


### PR DESCRIPTION
# Add environment variable to select renderer backend

- Modified `getAPI()` to check for `VOX_RENDERER=vulkan` and default to OpenGL otherwise
- Improved test script output messages to clearly indicate which backend is being tested
