### PR TITLE
fix(Vox/Platform/Vulkan): set proper window hints, apple device extension

### DIFF
--- a/vox/src/platform/vulkan/vulkan_context.h
+++ b/vox/src/platform/vulkan/vulkan_context.h
@@ -109,6 +109,9 @@ namespace Vox {
 
         const std::vector<const char*> mDeviceExtensions = {
             VK_KHR_SWAPCHAIN_EXTENSION_NAME,
+#ifdef __APPLE__
+            "VK_KHR_portability_subset",
+#endif
         };
 
 #ifdef NDEBUG

--- a/vox/src/vox/window.cpp
+++ b/vox/src/vox/window.cpp
@@ -33,13 +33,24 @@ namespace Vox {
             s_GLFWInitialized = true;
         }
 
-        // Request OpenGL 3.3 core profile
-        glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
-        glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
-        glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
+        // Set window hints based on renderer API
+        switch (Renderer::getAPI()) {
+            case RendererAPI::API::OpenGL:
+                // Request OpenGL 3.3 core profile
+                glfwWindowHint(GLFW_CONTEXT_VERSION_MAJOR, 3);
+                glfwWindowHint(GLFW_CONTEXT_VERSION_MINOR, 3);
+                glfwWindowHint(GLFW_OPENGL_PROFILE, GLFW_OPENGL_CORE_PROFILE);
 #if defined(__APPLE__)
-        glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
+                glfwWindowHint(GLFW_OPENGL_FORWARD_COMPAT, GL_TRUE);
 #endif
+                break;
+            case RendererAPI::API::Vulkan:
+                // Vulkan requires no client API
+                glfwWindowHint(GLFW_CLIENT_API, GLFW_NO_API);
+                break;
+            default:
+                throw std::runtime_error("Unknown RendererAPI!");
+        }
 
         return new Window(title, width, height);
     }


### PR DESCRIPTION
- Added the `VK_KHR_portability_subset` extension for Vulkan on macOS platforms
- Refactored window creation to configure GLFW window hints based on the selected renderer API:
  - For OpenGL: Sets up OpenGL 3.3 core profile with forward compatibility on macOS
  - For Vulkan: Sets `GLFW_CLIENT_API` to `GLFW_NO_API` as required by Vulkan
  - Added error handling for unknown renderer APIs