### PR TITLE
feat(Vox): add uniform abstraction to Shader interface

### DIFF
--- a/cube23/src/cube_app.cpp
+++ b/cube23/src/cube_app.cpp
@@ -36,7 +36,7 @@ public:
         mYingaTexture = Vox::Texture2D::create("textures/yinga.png");
 
         shader->bind();
-        std::dynamic_pointer_cast<Vox::OpenGLShader>(shader)->uploadUniformInt("u_texture", 0);
+        shader->setInt("u_texture", 0);
     }
 
     ~Cube() {}

--- a/vox/src/platform/opengl/shader.cpp
+++ b/vox/src/platform/opengl/shader.cpp
@@ -146,37 +146,37 @@ namespace Vox {
         glUseProgram(0);
     }
 
-    void OpenGLShader::uploadUniformInt(const std::string &name, const int value) const {
+    void OpenGLShader::setInt(const std::string &name, int value) {
         const GLint location = glGetUniformLocation(mRendererID, name.c_str());
         glUniform1i(location, value);
     }
 
-    void OpenGLShader::uploadUniformFloat(const std::string &name, const float value) const {
+    void OpenGLShader::setFloat(const std::string &name, float value) {
         const GLint location = glGetUniformLocation(mRendererID, name.c_str());
         glUniform1f(location, value);
     }
 
-    void OpenGLShader::uploadUniformFloat2(const std::string &name, const glm::vec2 &value) const {
+    void OpenGLShader::setFloat2(const std::string &name, const glm::vec2 &value) {
         const GLint location = glGetUniformLocation(mRendererID, name.c_str());
         glUniform2f(location, value.x, value.y);
     }
 
-    void OpenGLShader::uploadUniformFloat3(const std::string &name, const glm::vec3 &value) const {
+    void OpenGLShader::setFloat3(const std::string &name, const glm::vec3 &value) {
         const GLint location = glGetUniformLocation(mRendererID, name.c_str());
         glUniform3f(location, value.x, value.y, value.z);
     }
 
-    void OpenGLShader::uploadUniformFloat4(const std::string &name, const glm::vec4 &value) const {
+    void OpenGLShader::setFloat4(const std::string &name, const glm::vec4 &value) {
         const GLint location = glGetUniformLocation(mRendererID, name.c_str());
         glUniform4f(location, value.x, value.y, value.z, value.w);
     }
 
-    void OpenGLShader::uploadUniformMat3(const std::string &name, const glm::mat3 &matrix) const {
+    void OpenGLShader::setMat3(const std::string &name, const glm::mat3 &matrix) {
         const GLint location = glGetUniformLocation(mRendererID, name.c_str());
         glUniformMatrix3fv(location, 1, GL_FALSE, value_ptr(matrix));
     }
 
-    void OpenGLShader::uploadUniformMat4(const std::string &name, const glm::mat4 &matrix) const {
+    void OpenGLShader::setMat4(const std::string &name, const glm::mat4 &matrix) {
         const GLint location = glGetUniformLocation(mRendererID, name.c_str());
         glUniformMatrix4fv(location, 1, GL_FALSE, value_ptr(matrix));
     }

--- a/vox/src/platform/opengl/shader.h
+++ b/vox/src/platform/opengl/shader.h
@@ -19,15 +19,13 @@ namespace Vox {
 
         const std::string &getName() const override { return mName; }
 
-        void uploadUniformInt(const std::string &name, int value) const;
-
-        void uploadUniformFloat(const std::string &name, float value) const;
-        void uploadUniformFloat2(const std::string &name, const glm::vec2 &value) const;
-        void uploadUniformFloat3(const std::string &name, const glm::vec3 &value) const;
-        void uploadUniformFloat4(const std::string &name, const glm::vec4 &value) const;
-
-        void uploadUniformMat3(const std::string &name, const glm::mat3 &matrix) const;
-        void uploadUniformMat4(const std::string &name, const glm::mat4 &matrix) const;
+        void setInt(const std::string &name, int value) override;
+        void setFloat(const std::string &name, float value) override;
+        void setFloat2(const std::string &name, const glm::vec2 &value) override;
+        void setFloat3(const std::string &name, const glm::vec3 &value) override;
+        void setFloat4(const std::string &name, const glm::vec4 &value) override;
+        void setMat3(const std::string &name, const glm::mat3 &matrix) override;
+        void setMat4(const std::string &name, const glm::mat4 &matrix) override;
 
     private:
         static std::string readFile(const std::string &filepath);

--- a/vox/src/vox/renderer/renderer.cpp
+++ b/vox/src/vox/renderer/renderer.cpp
@@ -19,9 +19,8 @@ namespace Vox {
     void Renderer::submit(const std::shared_ptr<Shader> &shader, const std::shared_ptr<VertexArray> &vertexArray,
                           const glm::mat4 &transform) {
         shader->bind();
-        std::dynamic_pointer_cast<OpenGLShader>(shader)->uploadUniformMat4(
-            "u_viewProjection", sSceneData->viewProjectionMatrix);
-        std::dynamic_pointer_cast<OpenGLShader>(shader)->uploadUniformMat4("u_transform", transform);
+        shader->setMat4("u_viewProjection", sSceneData->viewProjectionMatrix);
+        shader->setMat4("u_transform", transform);
 
         vertexArray->bind();
         RenderCommand::drawIndexed(vertexArray);

--- a/vox/src/vox/renderer/shader.h
+++ b/vox/src/vox/renderer/shader.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <glm/glm.hpp>
 
 namespace Vox {
     class Shader {
@@ -13,6 +14,14 @@ namespace Vox {
         virtual void unbind() = 0;
 
         virtual const std::string &getName() const = 0;
+
+        virtual void setInt(const std::string &name, int value) = 0;
+        virtual void setFloat(const std::string &name, float value) = 0;
+        virtual void setFloat2(const std::string &name, const glm::vec2 &value) = 0;
+        virtual void setFloat3(const std::string &name, const glm::vec3 &value) = 0;
+        virtual void setFloat4(const std::string &name, const glm::vec4 &value) = 0;
+        virtual void setMat3(const std::string &name, const glm::mat3 &matrix) = 0;
+        virtual void setMat4(const std::string &name, const glm::mat4 &matrix) = 0;
 
         static std::shared_ptr<Shader> create(const std::string &filepath);
         static std::shared_ptr<Shader> create(const std::string &name, const std::string &vertexSrc,


### PR DESCRIPTION
Add setInt/setFloat/setMat4 methods to abstract Shader class for API-agnostic uniform handling. Update OpenGLShader to implement new interface while maintaining backward compatibility with legacy upload methods.

This enables cube23 to use shader->setInt() instead of OpenGL-specific casting, preparing for Vulkan backend implementation.