### PR TITLE
chore: update VSCode launch and tasks config for vkdemo

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -28,17 +28,17 @@
             "preLaunchTask": "build cube23"
         },
         {
-            "name": "Debug cube23_vk (Vulkan)",
+            "name": "Debug vkdemo (Vulkan)",
             "type": "cppdbg",
             "request": "launch",
-            "program": "${workspaceFolder}/cmake-build-debug/cube23_vk",
+            "program": "${workspaceFolder}/cmake-build-debug/vkdemo/vkdemo",
             "args": [],
             "stopAtEntry": false,
             "cwd": "${workspaceFolder}/cmake-build-debug",
             "environment": [],
             "externalConsole": false,
             "MIMode": "lldb",
-            "preLaunchTask": "build cube23_vk"
+            "preLaunchTask": "build vkdemo"
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -47,14 +47,14 @@
             "problemMatcher": ["$gcc"]
         },
         {
-            "label": "build cube23_vk",
+            "label": "build vkdemo",
             "type": "shell",
             "command": "cmake",
             "args": [
                 "--build",
                 "cmake-build-debug",
                 "--target",
-                "cube23_vk",
+                "vkdemo",
                 "-j",
                 "10"
             ],


### PR DESCRIPTION
Updated VS Code configuration files to reflect the renaming of the Vulkan demo.