### PR TITLE
feat(Vox): implement uniform buffer objects for shader data

### DIFF
--- a/cube23/assets/shaders/texture.glsl
+++ b/cube23/assets/shaders/texture.glsl
@@ -6,8 +6,13 @@
 layout(location = 0) in vec3 a_position;
 layout(location = 1) in vec2 a_texCoord;
 
-uniform mat4 u_viewProjection;
-uniform mat4 u_transform;
+layout(std140) uniform CameraData {
+    mat4 u_viewProjection;
+};
+
+layout(std140) uniform ObjectData {
+    mat4 u_transform;
+};
 
 out vec2 v_texCoord;
 

--- a/vox/src/platform/opengl/buffer.cpp
+++ b/vox/src/platform/opengl/buffer.cpp
@@ -38,4 +38,28 @@ namespace Vox {
     void OpenGLIndexBuffer::unbind() const {
         glBindBuffer(GL_ELEMENT_ARRAY_BUFFER, 0);
     }
+
+    OpenGLUniformBuffer::OpenGLUniformBuffer(uint32_t size, uint32_t binding) : mBinding(binding) {
+        glGenBuffers(1, &mRendererID);
+        glBindBuffer(GL_UNIFORM_BUFFER, mRendererID);
+        glBufferData(GL_UNIFORM_BUFFER, size, nullptr, GL_DYNAMIC_DRAW);
+        glBindBufferBase(GL_UNIFORM_BUFFER, binding, mRendererID);
+    }
+
+    OpenGLUniformBuffer::~OpenGLUniformBuffer() {
+        glDeleteBuffers(1, &mRendererID);
+    }
+
+    void OpenGLUniformBuffer::bind() const {
+        glBindBuffer(GL_UNIFORM_BUFFER, mRendererID);
+    }
+
+    void OpenGLUniformBuffer::unbind() const {
+        glBindBuffer(GL_UNIFORM_BUFFER, 0);
+    }
+
+    void OpenGLUniformBuffer::setData(const void* data, uint32_t size, uint32_t offset) {
+        glBindBuffer(GL_UNIFORM_BUFFER, mRendererID);
+        glBufferSubData(GL_UNIFORM_BUFFER, offset, size, data);
+    }
 }

--- a/vox/src/platform/opengl/buffer.h
+++ b/vox/src/platform/opengl/buffer.h
@@ -33,4 +33,18 @@ namespace Vox {
         uint32_t mRendererID;
         uint32_t mCount;
     };
+
+    class OpenGLUniformBuffer : public UniformBuffer {
+    public:
+        OpenGLUniformBuffer(uint32_t size, uint32_t binding);
+        ~OpenGLUniformBuffer() override;
+
+        void bind() const override;
+        void unbind() const override;
+        void setData(const void* data, uint32_t size, uint32_t offset = 0) override;
+
+    private:
+        uint32_t mRendererID;
+        uint32_t mBinding;
+    };
 }

--- a/vox/src/platform/opengl/shader.cpp
+++ b/vox/src/platform/opengl/shader.cpp
@@ -136,6 +136,17 @@ namespace Vox {
 
         for (const auto id : glShaderIDs)
             glDetachShader(mRendererID, id);
+
+        // Set uniform block bindings for OpenGL 3.3 compatibility
+        GLuint cameraBlockIndex = glGetUniformBlockIndex(mRendererID, "CameraData");
+        if (cameraBlockIndex != GL_INVALID_INDEX) {
+            glUniformBlockBinding(mRendererID, cameraBlockIndex, 0);
+        }
+        
+        GLuint objectBlockIndex = glGetUniformBlockIndex(mRendererID, "ObjectData");
+        if (objectBlockIndex != GL_INVALID_INDEX) {
+            glUniformBlockBinding(mRendererID, objectBlockIndex, 1);
+        }
     }
 
     void OpenGLShader::bind() {

--- a/vox/src/vox/renderer/buffer.cpp
+++ b/vox/src/vox/renderer/buffer.cpp
@@ -28,4 +28,17 @@ namespace Vox {
                 throw std::runtime_error("Unknown RendererAPI!");
         }
     }
+
+    std::shared_ptr<UniformBuffer> UniformBuffer::create(uint32_t size, uint32_t binding) {
+        switch (Renderer::getAPI()) {
+            case RendererAPI::API::None:
+                throw std::runtime_error("RendererAPI::None is currently not supported!");
+            case RendererAPI::API::OpenGL:
+                return std::make_shared<OpenGLUniformBuffer>(size, binding);
+            case RendererAPI::API::Vulkan:
+                return std::make_shared<VulkanUniformBuffer>(size, binding);
+            default:
+                throw std::runtime_error("Unknown RendererAPI!");
+        }
+    }
 }

--- a/vox/src/vox/renderer/buffer.h
+++ b/vox/src/vox/renderer/buffer.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include <memory>
 #include <stdexcept>
 #include <utility>
 #include <vector>
@@ -117,5 +118,16 @@ namespace Vox {
         virtual uint32_t getCount() const = 0;
 
         static IndexBuffer *create(uint32_t *indices, uint32_t count);
+    };
+
+    class UniformBuffer {
+    public:
+        virtual ~UniformBuffer() {}
+
+        virtual void bind() const = 0;
+        virtual void unbind() const = 0;
+        virtual void setData(const void* data, uint32_t size, uint32_t offset = 0) = 0;
+
+        static std::shared_ptr<UniformBuffer> create(uint32_t size, uint32_t binding);
     };
 }

--- a/vox/src/vox/renderer/renderer.cpp
+++ b/vox/src/vox/renderer/renderer.cpp
@@ -4,13 +4,19 @@
 
 namespace Vox {
     Renderer::SceneData *Renderer::sSceneData = new SceneData;
+    std::shared_ptr<UniformBuffer> Renderer::sCameraUniformBuffer = nullptr;
+    std::shared_ptr<UniformBuffer> Renderer::sObjectUniformBuffer = nullptr;
 
     void Renderer::init() {
         RenderCommand::init();
+        
+        sCameraUniformBuffer = UniformBuffer::create(sizeof(glm::mat4), 0);
+        sObjectUniformBuffer = UniformBuffer::create(sizeof(glm::mat4), 1);
     }
 
     void Renderer::beginScene(const OrthographicCamera &camera) {
         sSceneData->viewProjectionMatrix = camera.getViewProjectionMatrix();
+        sCameraUniformBuffer->setData(&sSceneData->viewProjectionMatrix, sizeof(glm::mat4));
     }
 
     void Renderer::endScene() {
@@ -19,8 +25,8 @@ namespace Vox {
     void Renderer::submit(const std::shared_ptr<Shader> &shader, const std::shared_ptr<VertexArray> &vertexArray,
                           const glm::mat4 &transform) {
         shader->bind();
-        shader->setMat4("u_viewProjection", sSceneData->viewProjectionMatrix);
-        shader->setMat4("u_transform", transform);
+        
+        sObjectUniformBuffer->setData(&transform, sizeof(glm::mat4));
 
         vertexArray->bind();
         RenderCommand::drawIndexed(vertexArray);

--- a/vox/src/vox/renderer/renderer.h
+++ b/vox/src/vox/renderer/renderer.h
@@ -3,6 +3,7 @@
 #include "vox/renderer/orthographic_camera.h"
 #include "vox/renderer/render_command.h"
 #include "vox/renderer/shader.h"
+#include "vox/renderer/buffer.h"
 
 namespace Vox {
     class Renderer {
@@ -23,5 +24,7 @@ namespace Vox {
         };
 
         static SceneData *sSceneData;
+        static std::shared_ptr<UniformBuffer> sCameraUniformBuffer;
+        static std::shared_ptr<UniformBuffer> sObjectUniformBuffer;
     };
 }


### PR DESCRIPTION
Implemented Uniform Buffer Objects (UBOs) to optimize shader uniform handling.

- Added `UniformBuffer` abstract class and OpenGL implementation
- Modified shader system to use UBOs for camera and object data
- Updated the texture shader to use UBO layout(std140) uniform blocks
- Added binding points for camera data (binding 0) and object data (binding 1)
- Implemented automatic binding of uniform blocks in the OpenGL shader implementation
- Updated the renderer to use UBOs instead of individual uniform calls